### PR TITLE
Detect ARM64 macOS running on Apple Silicon

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-
-declare function arch(): 'x64' | 'x86';
+declare function arch(): 'x64' | 'x86' | 'arm64';
 
 export = arch;

--- a/index.js
+++ b/index.js
@@ -17,10 +17,15 @@ module.exports = function arch () {
   }
 
   /**
-   * All recent versions of Mac OS are 64-bit.
+   * On macOS, we need to detect if x64 Node is running because the CPU is truly
+   * an Intel chip, or if it's running on Apple Silicon via Rosetta 2:
+   * https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
    */
   if (process.platform === 'darwin') {
-    return 'x64'
+    var nativeArm = process.arch === 'arm64'
+    var rosettaArm = cp.execSync('sysctl -in sysctl.proc_translated', { encoding: 'utf8' }) === '1\n'
+
+    return (nativeArm || rosettaArm) ? 'arm64' : 'x64'
   }
 
   /**

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,8 +1,8 @@
 var arch = require('../')
 var test = require('tape')
 
-test('returns x86 or x64', function (t) {
+test('returns a valid architecture', function (t) {
   var str = arch()
-  t.ok(str === 'x86' || str === 'x64')
+  t.ok(str === 'x86' || str === 'x64' || str === 'arm64')
   t.end()
 })


### PR DESCRIPTION
This also distinguishes whether x64 Node is running because we're actually on an Intel Mac or if it's just [Rosetta 2](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) pretending to be one. If there's someone smarter than me who has a cleaner method please chime in ;)

Regarding #19: I didn't touch the Linux logic because I don't have as strong of an understanding there (and it seems [a lot tricker](https://unix.stackexchange.com/questions/136407/is-my-linux-arm-32-or-64-bit) to do — is it safe to assume `uname` is on every machine?) but it'd be helpful to do the same thing there for both 32-bit and 64-bit ARM. If this PR looks good I can look further into it!